### PR TITLE
Avoid recursive loading of config

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ modules.exports = require('sails-env-switch').switch('internal',{
 });
 ```
 
-If you are using `env-lift` also in the sails project, this module can be used with that module too
+If you are using `env-lift` also in the sails project, this module should be used with `env-lift`
 
 __Original Code:__
 
@@ -141,7 +141,7 @@ external behaviour of the service.
 - If `SAILS_ENV` is not defined, then the config will be picked by the sails as usual.
 - If `SAILS_ENV` is defined to some name, then the same named file should be present in `config/env` folder of sails,
  otherwise it will break
-- This module is not the alternative for `env-lift`, this module can be used with `env-lift` to switch the env config
+- This module is not the alternative for `env-lift`, this module should be used with `env-lift` to switch the env config
  based on `SAILS_ENV` value.
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ __Updated code using sail-env-switch:__
 
 ```javascript
 // production.js
-modules.exports = require('sails-env-switch').switch({
+modules.exports = require('sails-env-switch').switch('production',{
   port: 80,
   environment: 'production',
   routes: {
@@ -57,19 +57,19 @@ modules.exports = require('sails-env-switch').switch({
 });
 ```
 
-At this stage you have `SAILS_ENV` variable set to `internal`.
+At this stage you have `SAILS_ENV` variable is set to `internal`.
 
 __Code for Internal.js__
 
 ```javascript
-modules.exports = {
+modules.exports = require('sails-env-switch').switch('internal',{
   port: 8080,
     environment: 'production',
     routes: {
       'GET /x/foo': 'dummyController.getFoo'
       'POST /x/bar': 'dummyController.postBar'
     }
-};
+});
 ```
 
 Now if you open the sails console and try to get the sails config and other variables.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,51 @@ modules.exports = require('sails-env-switch').switch('internal',{
 });
 ```
 
+If you are using `env-lift` also in the sails project, this module can be used with that module too
+
+__Original Code:__
+
+```javascript
+// production.js
+modules.exports = require('env-lift').load('sails-project-name', {
+  port: 80,
+  environment: 'production',
+  routes: {
+    'GET /foo': 'dummyController.get'
+    'POST /bar': 'dummyController.post'
+  }
+});
+```
+
+__Updated code using sail-env-switch:__
+
+```javascript
+// production.js
+modules.exports = require('env-lift').load('sails-project-name', require('sails-env-switch').switch('production',{
+  port: 80,
+  environment: 'production',
+  routes: {
+    'GET /foo': 'dummyController.get'
+    'POST /bar': 'dummyController.post'
+  }
+}));
+```
+
+At this stage you have `SAILS_ENV` variable is set to `internal`.
+
+__Code for Internal.js__
+
+```javascript
+modules.exports = require('env-lift').load('sails-project-name', require('sails-env-switch').switch('internal',{
+  port: 8080,
+    environment: 'production',
+    routes: {
+      'GET /x/foo': 'dummyController.getFoo'
+      'POST /x/bar': 'dummyController.postBar'
+    }
+}));
+```
+
 Now if you open the sails console and try to get the sails config and other variables.
 
 ```terminal
@@ -96,6 +141,8 @@ external behaviour of the service.
 - If `SAILS_ENV` is not defined, then the config will be picked by the sails as usual.
 - If `SAILS_ENV` is defined to some name, then the same named file should be present in `config/env` folder of sails,
  otherwise it will break
+- This module is not the alternative for `env-lift`, this module can be used with `env-lift` to switch the env config
+ based on `SAILS_ENV` value.
 
 
  ## Contribution

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -2,7 +2,7 @@
  * @fileOverview This is a variation of a SailsJS local.js file that uses env-lift to provide configuration overrides
  * from environment variables.
  */
-module.exports = require('../../index').switch({
+module.exports = require('../../index').switch('development', {
 
   // Your SSL certificate and key, if you want to be able to serve HTTP responses
   // over https:// and/or use websockets over the wss:// protocol

--- a/config/env/internal.js
+++ b/config/env/internal.js
@@ -2,7 +2,7 @@
  * @fileOverview This is a variation of a SailsJS local.js file that uses env-lift to provide configuration overrides
  * from environment variables.
  */
-module.exports = {
+module.exports = require('../../index').switch('internal', {
 
   // Your SSL certificate and key, if you want to be able to serve HTTP responses
   // over https:// and/or use websockets over the wss:// protocol
@@ -64,4 +64,4 @@ module.exports = {
   foo: {
     bar: 'dummy'
   }
-};
+});

--- a/lib/main.js
+++ b/lib/main.js
@@ -4,13 +4,14 @@ module.exports = {
    * defined to some value then it expects that same file in the env/config file so that it
    * will pick the config value from that file.
    *
+   * @param env this is the current sails environment in which this module is used.
    * @param defaultConfig this is the default config which is bases on NODE_ENV value
    * @returns {config}
    *
    *
    * @example
    * // This is the env config file
-   * module.exports = require('sails-env-switch').switch({
+   * module.exports = require('sails-env-switch').switch('development', {
    *    port: 8080,
    *    name: 'Sample'
    * });
@@ -32,7 +33,12 @@ module.exports = {
    * // Here NODE_ENV will not be disturbed at all just the config will be picked based on SAILS_ENV
    *
    */
-  switch: function (defaultConfig) {
+  switch: function (env, defaultConfig) {
+    // This will avoid recursive loading of config as if the current env is same as SAILS_ENV, then just return the
+    // defaultConfig
+    if (process.env.SAILS_ENV === env) {
+      return defaultConfig;
+    }
     return process.env.SAILS_ENV ? require(process.cwd() + '/config/env/' + process.env.SAILS_ENV) : defaultConfig;
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-env-switch",
-  "version": "0.0.0",
+  "version": "0.0.1-beta.1",
   "description": "loads environment config based on SAILS_ENV value",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Now this module will take two params:- 
1. The current environment from which this module is called
2. The default config which needs to load when SAILS_ENV is not defined.

It now checks if the current environment is same as the SAILS_ENV, then to avoid recursion and to prevent infinite config loading we return the default config.

