### PR TITLE
feat: Add error-stack check as fallback for parent filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ module.exports = {
 
     // if getting parent file name from module failed then use error-stack to fetch the parent file path
     if(path.relative(targetFile, getParentFilePath()) === '') {
-        console.log("Test is here");
         return defaultConfig;
     }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var path = require('path');
 
+const { getParentFilePath } = require('./utils')
+
 module.exports = {
   /**
    * It will pick the env config based on the SAILS_ENV value. If a project has SAILS_ENV
@@ -51,6 +53,12 @@ module.exports = {
     // If the current file from which this file is called is internal.js, then return the config of that file.
     if (path.relative(targetFile, module.parent.filename) === '') {
       return defaultConfig;
+    }
+
+    // if getting parent file name from module failed then use error-stack to fetch the parent file path
+    if(path.relative(targetFile, getParentFilePath()) === '') {
+        console.log("Test is here");
+        return defaultConfig;
     }
 
     // Cache for this file has to be cleared as this hook depends on the parent module from which this has been

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-env-switch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "loads environment config based on SAILS_ENV value",
   "main": "index.js",
   "scripts": {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,20 @@
+module.exports = {
+    getParentFilePath: function () {
+        try {
+            const stack = new Error().stack.split('\n');
+
+            /**
+             * We are picking 3rd index of stack trace.
+             * Error -> getParentFilePath() -> index.js -> parent module calling index.js
+             * [0] -> [1] -> [2] -> [3]
+             * Ref: https://stackoverflow.com/a/63039252
+             */
+            return stack[3].slice(
+                stack[3].lastIndexOf('(')+1,
+                stack[3].lastIndexOf('.js')+3
+            )
+        } catch (err) {
+            return '';
+        }
+    }
+}


### PR DESCRIPTION
### Why?
* There can be a possibility when `module.parent.filename` might not give the correct parent.
* This can happen when even after `delete require.cache()` the cache is not deleted and it is used in the next calls to the package by other functions.
* The cache not getting deleted correctly can happen if there is a hook on `require` module which uses it's own cache mechanism.
* In this case every time the first module which is called switch() will be returned as filename.

### What?
To handle this issue, we will be adding the `error stack` method to fetch the parent filename if it fails to get the correct parent filename using the `module.parent` method

### How?
* Create a new `getParentFilePath()` function in utils.js which is called after the `parent.module.filename` check which will return the parent file name from the created stack
* Rest of the functionality will be retained as it is the error stack is being used as a fallback option only.
